### PR TITLE
add support for multiple divisions/multiple paymill accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ require 'paymill'
 Paymill.api_key = ENV['PAYMILL_API_TEST_PRIVATE_KEY']
 ```
 
+If you need to manage multiple divisions with different secret api keys of multiple Paymill accounts, see below.
+
 Clients
 -------
 
@@ -200,6 +202,25 @@ Checksum.create( checksum_type: 'paypal', amount: 9700, currency: 'EUR', descrip
 
 ```ruby
 Checksum.create( checksum_type: 'paypal', amount: 9700, currency: 'EUR', description: 'Chuck Testa', return_url: 'https://testa.com', cancel_url: 'https://test.com/cancel', fee_amount: 100, fee_payment: 'pay_3af44644dd6d25c820a8', fee_currency: 'EUR', app_id: '8fh98hfd828ej2e09dk0hf9' )
+```
+
+Multiple Paymill accounts support
+=================================
+
+It is also possible to add multiple divisions, if you need to access multiple Paymill accounts.
+
+```ruby
+require 'paymill'
+
+Paymill.add_api_key( 'division_1', 'PRIVATE API KEY DIVISION 1' )
+Paymill.add_api_key( 'division_2', 'PRIVATE API KEY DIVISION 2' )
+```
+
+You access each division by passing the division's key to the query:
+
+```ruby
+clients = Paymill::Client.all( division: 'division_1' )
+offer = Offer.find( 'offer_b54ff8b3811e06c02e14', division: 'division_2' )
 ```
 
 Contributing

--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -26,20 +26,26 @@ module Paymill
   autoload :Transaction,          'paymill/models/transaction'
   autoload :Webhook,              'paymill/models/webhook'
 
+  @@api_keys = {}
+
   def self.api_version
     API_VERSION
   end
 
-  def self.api_key
-    @@api_key
+  def self.api_key(slug = :default)
+    @@api_keys[slug]
   end
 
   def self.api_key=( api_key )
-    @@api_key = api_key
+    @@api_keys[:default] = api_key
   end
 
-  def self.request( payload )
-    raise AuthenticationError unless Paymill.api_key
+  def self.add_api_key(slug, api_key)
+    @@api_keys[slug]= api_key
+  end
+
+  def self.request( payload, api_key )
+    raise AuthenticationError unless api_key
     https ||= Net::HTTP.new( API_BASE, Net::HTTP.https_default_port)
     https.use_ssl = true
 

--- a/lib/paymill/restful/methods.rb
+++ b/lib/paymill/restful/methods.rb
@@ -14,7 +14,6 @@ module Paymill
         end
 
         api_key = Paymill.api_key( arguments[:division] || :default )
-        puts Paymill.api_key( :default )
         payload = Http.all( Restful.demodulize_and_tableize( name ), api_key, arguments )
         response = Paymill.request( payload, api_key )
         enrich_array_with_data_count( response['data'].map!{ |element| new( element ) }, response['data_count'] )

--- a/samples/authentication/multiple_authentications.rb
+++ b/samples/authentication/multiple_authentications.rb
@@ -1,0 +1,12 @@
+api_keys = {
+  'organisation_1' => "<YOUR_PRIVATE_KEY_1>",
+  'organisation_2' => "<YOUR_PRIVATE_KEY_2>"
+}
+
+api_keys.each do |api_key_slug, api_key|
+  Paymill.add_api_key(api_key_slug, api_key)
+end
+
+# to switch between different access keys:
+
+Paymill::Transaction.find('<YOUR_TRANSACTION_ID>', division: 'organisation_1')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'pry'
 require 'active_support/all'
 require 'uri'
 
-# initialize the library by getting paymill's api key from the envirounent variables
+# initialize the library by getting paymill's api key from the environment variables
 Paymill.api_key = ENV['PAYMILL_API_TEST_PRIVATE_KEY']
 
 # VCR basic configuration


### PR DESCRIPTION
With this change, it is possible to configure multiple paymill API access accounts (divisions) by passing the division’s name in the query.
